### PR TITLE
Implement new scoring in confusion matrix

### DIFF
--- a/confusion_matrix.py
+++ b/confusion_matrix.py
@@ -8,6 +8,7 @@
 # ----------------------------------------------------------------------
 
 import numpy
+import math
 
 class ConfusionMatrixBase(object):
   """
@@ -48,16 +49,21 @@ class ConfusionMatrixBase(object):
     else:
       self.ppv = self.fdr = 0.0
       
-  def setCost(self, costMatrix):
+  def setCost(self, costMatrix, additionalCost = 0):
     """
     Determines and sets the total expected cost associated with a system
     represented by this confusion matrix.
+
+    costMatrix - Cost values for each quadrent of the confusion matrix
+    additionalCost - Any other calculated costs to add to the final total
     """
     
     self.cost = ((self.tp * costMatrix['tpCost']) +
                   (self.fp * costMatrix['fpCost']) +
                   (self.fn * costMatrix['fnCost']) +
                   (self.tn * costMatrix['tnCost']))
+
+    self.cost += additionalCost
 
   def getTotal(self):
     """
@@ -66,6 +72,164 @@ class ConfusionMatrixBase(object):
     
     return self.tp + self.fp + self.fn + self.tn + self.ignored
 
+
+class WindowedConfusionMatrixV2(ConfusionMatrixBase):
+  
+  def __init__(self,
+               predicted,
+               actual,
+               window,
+               windowStepSize,
+               costMatrix = None,
+               verbosity = 0):
+    """
+    Generate the confusion matrix using the windowed method
+    
+     True Positives - An anomalous record followed in the next window minutes
+                      by at least one above threshold likelihood score
+                                           OR
+                     Any likelihood score above threshold preceeded by an
+                     an anomalous record within the last window minutes.
+                     NOTE: We intentionally ignore this type of TP as we
+                     don't want to optimize for it.
+     False Negatives - Any anomalous record without an above threshold
+                      likelihood score within the next window minutes
+     False Positives - Any above threshold likelihood score preceeded by window
+                       minutes without an anomalous record
+     True Negatives - Any below threshold likelihood score preceeded by window
+                      minutes without an anomalous record
+                      
+    predicted       - A list or numpy array
+    actual          - A list or numpy array
+    window          - Number of minutes we should calculate stats over
+    windowStepSize  - Minutes per record
+    costMatrix      - A dict of costs for each quadrent of the confusion matrix
+    verbosity       - How much output (if any) should be printed
+    """
+    self.tp = self.fp = self.fn = self.tn = self.ignored = 0.0
+    
+    # Default to even, zero-cost for each type of result
+    if costMatrix == None:
+      costMatrix = {"tpCost": 0.0,
+                    "fpCost": 0.0,
+                    "fnCost": 0.0,
+                    "tnCost": 0.0}
+      
+    
+    # Convert predicted and actual to numpy arrays if they are not
+    predicted = numpy.array(predicted)
+    actual = numpy.array(actual)
+    
+    # Label numbers and names
+    aTypes = {1: 'handLabeledAnomaly'}
+    ignoreTypes = {0.5: 'unclearRecord'}
+    
+    # How many records are in our window
+    recordCount = window / windowStepSize
+    
+    # Per record late penalty is a fraction of a full false negative
+    latePenalty = (.5 * costMatrix["fnCost"]) / recordCount
+
+    # Go through all the results
+    suppressDuration = recordCount
+    self.count = len(actual)
+    allowedWindow = 0
+    suppresionWindow = 0
+    latePenaltyTotal = 0
+    for i, label in enumerate(actual):
+
+
+      if allowedWindow and suppresionWindow:
+        raise Exception("We should never be in both an allowed and supression "
+                        "window at the same time.")
+
+      # Are we waiting for the detector to catch an anomaly?
+      if allowedWindow >= 1:
+        if verbosity > 1: print i, "ALLOWED", predicted[i]
+        # Did the detector catch the anomaly here?
+        if predicted[i] == 1:
+          if verbosity > 1: print "CAUGHT"
+          self.tp += 1
+          # Calculate the earned late penalty to this point
+          latePenaltyTotal += (recordCount - allowedWindow) * latePenalty
+          # Zero out the allowed window
+          allowedWindow = 0
+          # Start the suppression period
+          suppresionWindow = suppressDuration
+          suppresionPenaltyEarned = False
+        # Detector didn't catch anomaly, continue countdown
+        else:
+          allowedWindow -= 1
+          # If we've run out of window, the detector failed.
+          if verbosity > 1: print allowedWindow
+          if allowedWindow == 0:
+            if verbosity > 1: print "FAILED"
+            self.fn += 1
+          else:
+            self.tn += 1
+
+        continue
+
+      # Have we caught an anomaly and we want to avoid spam?
+      elif suppresionWindow >= 1:
+        if verbosity > 1: print i, "SUPRESS", predicted[i]
+        # Have we already penalized the detector for spam?
+        if suppresionPenaltyEarned:
+          self.tn += 1
+          suppresionWindow -= 1
+        else:
+          # Penalize the detector and set the penalty flag
+          if predicted[i] == 1:
+            if verbosity > 1: print "SPAM"
+            self.fp += 1
+            suppresionPenaltyEarned = True
+          else:
+            self.tn += 1
+
+          # Count down our window
+          suppresionWindow -= 1
+
+        continue
+
+      #######################################################################
+      # Outside of allowed and suppression windows
+
+      # Is this record the start of an anomaly? (ground truth)
+      if verbosity > 1: print i, label, predicted[i]
+
+      if label in aTypes.keys():
+
+        # Is it caught immediately?
+        if predicted[i] == 1:
+          self.tp += 1
+          # Start the suppression period
+          suppresionWindow = suppressDuration
+          suppresionPenaltyEarned = False
+        # If not start the allowed window
+        else:
+          self.tn += 1
+          allowedWindow = recordCount - 1
+
+      # Is this an ambiguous record?
+      elif label in ignoreTypes.keys():
+        self.ignored += 1
+
+      # This record is not an anomaly
+      else:
+        # If the detector thinks it is
+        if predicted[i] == 1:
+          if verbosity > 1: print "FALSE POSITIVE"
+          self.fp += 1
+        # If the detector got it correct
+        else:
+          self.tn += 1
+
+      
+    assert self.getTotal() == self.count
+
+    self.setPercentages()
+    self.setRates()
+    self.setCost(costMatrix, math.floor(latePenaltyTotal))
 
 
 class WindowedConfusionMatrix(ConfusionMatrixBase):


### PR DESCRIPTION
@subutai While I'm re-labeling data I would appreciate it if you would review the logic in the confusion matrix for scoring.

Here is the English description of what the code does:
#### Scoring Rules
- For each record check if it is labeled (ground truth) as an anomaly
- If it is an anomaly
  - A detector has ALLOWED records to catch the anomaly
  - For each record that follows the start of the anomaly where the anomaly is not caught, there is a small penalty (LATE)
  - If the detector catches the anomaly, this is a True Positive
    - Once an anomaly has been flagged there is a SUPPRESSION period
    - To avoid spamming the end users a detector should not flag other records as anomalous during the SUPPRESSION period
    - If a detector flags one _or more_ additional records during a SUPPRESSION period, it is a False Positive (SPAM)
      - This reflects the binary nature of Spam. Once the useful detection has been made everything else is spam. Lots of spam is only marginally worse than any spam.
    - If a record is not flagged as an anomaly in the SUPPRESSION period this is a True Negative
  - If ALLOWED records elapse without the anomaly being caught it is a False Negative
- If it is not an anomaly, and we're not in an ALLOWED period or in a SUPPRESSION period
  - If it is flagged as an anomaly it is a False Positive
  - Otherwise it is a True Negative

ALLOWED is usually equal to SUPPRESSION, but doesn't have to be.
