### PR TITLE
normalization function and baseline detector

### DIFF
--- a/config/profiles.json
+++ b/config/profiles.json
@@ -10,7 +10,7 @@
 "reward low FP rate": {
 	"CostMatrix": {
     	"tpWeight": 1.0,
-    	"fnWeight": 0.5,
+    	"fnWeight": 1.0,
     	"fpWeight": 0.22,
     	"tnWeight": 1.0
 	}
@@ -19,7 +19,7 @@
 	"CostMatrix": {
     	"tpWeight": 1.0,
     	"fnWeight": 2.0,
-    	"fpWeight": 0.055,
+    	"fpWeight": 0.11,
     	"tnWeight": 1.0
 	}
   }

--- a/nab/detectors/baseline/baseline_detector.py
+++ b/nab/detectors/baseline/baseline_detector.py
@@ -1,0 +1,35 @@
+# ----------------------------------------------------------------------
+# Copyright (C) 2015, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""
+This detector establishes a baseline score by recording a constant value for all
+data points.
+"""
+
+from nab.detectors.base import AnomalyDetector
+
+
+
+class BaselineDetector(AnomalyDetector):
+
+  def handleRecord(self, inputData):
+    """The anomalyScore is simply a constant 0.5."""
+    anomalyScore = 0.5
+    return (anomalyScore, )

--- a/nab/detectors/baseline/baseline_detector.py
+++ b/nab/detectors/baseline/baseline_detector.py
@@ -33,3 +33,4 @@ class BaselineDetector(AnomalyDetector):
     """The anomalyScore is simply a constant 0.5."""
     anomalyScore = 0.5
     return (anomalyScore, )
+    

--- a/nab/runner.py
+++ b/nab/runner.py
@@ -245,3 +245,4 @@ class Runner(object):
         score = -base + results["Score"][len(results)-1]
       
       print "Final score for \'%s\' = %.2f" % (csvName[:-11], score)
+      

--- a/run.py
+++ b/run.py
@@ -166,3 +166,4 @@ if __name__ == "__main__":
 
   if args.skipConfirmation or checkInputs(args):
     main(args)
+    

--- a/run.py
+++ b/run.py
@@ -34,6 +34,7 @@ from nab.util import (detectorNameToClass, checkInputs)
 from nab.detectors.numenta.numenta_detector import NumentaDetector
 from nab.detectors.skyline.skyline_detector import SkylineDetector
 from nab.detectors.random.random_detector import RandomDetector
+from nab.detectors.baseline.baseline_detector import BaselineDetector
 
 
 
@@ -80,8 +81,10 @@ def main(args):
   if args.score:
     with open(args.thresholdsFile) as thresholdConfigFile:
       detectorThresholds = json.load(thresholdConfigFile)
-
     runner.score(args.detectors, detectorThresholds)
+
+  if args.normalize:
+    runner.normalize()
 
 
 if __name__ == "__main__":
@@ -105,16 +108,15 @@ if __name__ == "__main__":
                     default=False,
                     action="store_true")
 
+  parser.add_argument("--normalize",
+                    help="Normalize the final scores",
+                    default=False,
+                    action="store_true")
+                    
   parser.add_argument("--skipConfirmation",
                     help="If specified will skip the user confirmation step",
                     default=False,
                     action="store_true")
-
-  parser.add_argument("-d", "--detectors",
-                    nargs="*",
-                    type=str,
-                    default=["numenta", "random", "skyline"],
-                    help="Space separated list of detector(s) to use.")
 
   parser.add_argument("--dataDir",
                     default="data",
@@ -129,7 +131,13 @@ if __name__ == "__main__":
                     default=os.path.join("labels", "combined_labels.json"),
                     help="JSON file containing ground truth labels for the "
                          "corpus.")
-
+                         
+  parser.add_argument("-d", "--detectors",
+                    nargs="*",
+                    type=str,
+                    default=["baseline", "numenta", "random", "skyline"],
+                    help="Space separated list of detector(s) to use.")
+                    
   parser.add_argument("-p", "--profilesFile",
                     default="config/profiles.json",
                     help="The configuration file to use while running the "
@@ -147,10 +155,14 @@ if __name__ == "__main__":
 
   args = parser.parse_args()
   
-  if not args.detect and not args.score and not args.optimize:
+  if (not args.detect
+      and not args.optimize
+      and not args.score
+      and not args.normalize):
     args.detect = True
     args.optimize = True
     args.score = True
+    args.normalize = True
 
   if args.skipConfirmation or checkInputs(args):
     main(args)


### PR DESCRIPTION
@subutai please review
Fixes #116 
Includes a constant (baseline) detector, assuming we want to include the baseline detector in the repo; see discussion in #115. The printout is below (note: these scores are with different scaling for the FP and FN profiles than currently reflected in profile.json; see #123, which is fixed by commit c17908b below):

Running score normalization step
Final score for 'baseline_reward low FN rate' = 0.00
Final score for 'baseline_reward low FP rate' = 0.00
Final score for 'baseline_standard' = 0.00
Final score for 'numenta_reward low FN rate' = 101.96
Final score for 'numenta_reward low FP rate' = 58.87
Final score for 'numenta_standard' = 63.96
Final score for 'random_reward low FN rate' = 41.41
Final score for 'random_reward low FP rate' = 0.00
Final score for 'random_standard' = 18.11
Final score for 'skyline_reward low FN rate' = 64.13
Final score for 'skyline_reward low FP rate' = 28.27
Final score for 'skyline_standard' = 38.13

@scottpurdy I'm unsure of the format in [lines 158-165 of run.py](https://github.com/numenta/NAB/compare/numenta:master...BoltzmannBrain:scale_scores?expand=1#diff-6e38f16215ae91c11fc5c54b74c66d54R158). What do you think?