### PR TITLE
Add path checks

### DIFF
--- a/nab/labeler.py
+++ b/nab/labeler.py
@@ -139,18 +139,22 @@ class CorpusLabel(object):
     self.labels = {}
 
     for relativePath, dataSet in self.corpus.dataFiles.iteritems():
-      windows = self.windows[relativePath]
+      if self.windows.has_key(relativePath):
+        windows = self.windows[relativePath]
 
-      labels = pandas.DataFrame({"timestamp": dataSet.data["timestamp"]})
-      labels['label'] = 0
+        labels = pandas.DataFrame({"timestamp": dataSet.data["timestamp"]})
+        labels['label'] = 0
 
-      for t1, t2 in windows:
-        moreThanT1 = labels[labels["timestamp"] >= t1]
-        betweenT1AndT2 = moreThanT1[moreThanT1["timestamp"] <= t2]
-        indices = betweenT1AndT2.loc[:,"label"].index
-        labels["label"].values[indices.values] = 1
+        for t1, t2 in windows:
+          moreThanT1 = labels[labels["timestamp"] >= t1]
+          betweenT1AndT2 = moreThanT1[moreThanT1["timestamp"] <= t2]
+          indices = betweenT1AndT2.loc[:,"label"].index
+          labels["label"].values[indices.values] = 1
 
-      self.labels[relativePath] = labels
+        self.labels[relativePath] = labels
+
+      else:
+        print "Warning: no label for datafile",relativePath
 
 
 class LabelCombiner(object):

--- a/nab/runner.py
+++ b/nab/runner.py
@@ -113,20 +113,21 @@ class Runner(object):
     for detectorName, detectorConstructor in detectors.iteritems():
       for relativePath, dataSet in self.corpus.dataFiles.iteritems():
 
-        args.append(
-          (
-            count,
-            detectorConstructor(
-              dataSet=dataSet,
-              probationaryPercent=self.probationaryPercent),
-            detectorName,
-            self.corpusLabel.labels[relativePath]["label"],
-            self.resultsDir,
-            relativePath
+        if self.corpusLabel.labels.has_key(relativePath):
+          args.append(
+            (
+              count,
+              detectorConstructor(
+                dataSet=dataSet,
+                probationaryPercent=self.probationaryPercent),
+              detectorName,
+              self.corpusLabel.labels[relativePath]["label"],
+              self.resultsDir,
+              relativePath
+            )
           )
-        )
 
-        count += 1
+          count += 1
     
     self.pool.map(detectDataSet, args)
 


### PR DESCRIPTION
These changes don't require that every data file have a window definition. This lets you to run with a small window file for debugging. It warns you if there are data files for which you don't have windows.