### PR TITLE
Remove test for deprecated labels check

### DIFF
--- a/config/thresholds.json
+++ b/config/thresholds.json
@@ -55,20 +55,6 @@
             "threshold": 0.8000000000000003
         }
     },
-    "twitterADVec": {
-        "reward_low_FN_rate": {
-            "score": -30.63914483,
-            "threshold": 0.5
-        },
-        "reward_low_FP_rate": {
-            "score": -12.15798656,
-            "threshold": 0.5
-        },
-        "standard": {
-            "score": -8.639144834,
-            "threshold": 0.5
-        }
-    },
     "twitterADTs": {
         "reward_low_FN_rate": {
             "score": -39.9892525,
@@ -80,6 +66,20 @@
         },
         "standard": {
             "score": -14.9892525,
+            "threshold": 0.5
+        }
+    },
+    "twitterADVec": {
+        "reward_low_FN_rate": {
+            "score": -30.63914483,
+            "threshold": 0.5
+        },
+        "reward_low_FP_rate": {
+            "score": -12.15798656,
+            "threshold": 0.5
+        },
+        "standard": {
+            "score": -8.639144834,
             "threshold": 0.5
         }
     }

--- a/config/thresholds.json
+++ b/config/thresholds.json
@@ -55,20 +55,6 @@
             "threshold": 0.8000000000000003
         }
     },
-    "twitterADTs": {
-        "reward_low_FN_rate": {
-            "score": -39.9892525,
-            "threshold": 0.5
-        },
-        "reward_low_FP_rate": {
-            "score": -19.71923553,
-            "threshold": 0.5
-        },
-        "standard": {
-            "score": -14.9892525,
-            "threshold": 0.5
-        }
-    },
     "twitterADVec": {
         "reward_low_FN_rate": {
             "score": -30.63914483,
@@ -80,6 +66,20 @@
         },
         "standard": {
             "score": -8.639144834,
+            "threshold": 0.5
+        }
+    },
+    "twitterADTs": {
+        "reward_low_FN_rate": {
+            "score": -39.9892525,
+            "threshold": 0.5
+        },
+        "reward_low_FP_rate": {
+            "score": -19.71923553,
+            "threshold": 0.5
+        },
+        "standard": {
+            "score": -14.9892525,
             "threshold": 0.5
         }
     }

--- a/tests/integration/corpuslabel_test.py
+++ b/tests/integration/corpuslabel_test.py
@@ -115,31 +115,16 @@ class CorpusLabelTest(unittest.TestCase):
             % (row[1]["timestamp"], relativePath))
 
 
-  def testNonexistentDatafileOrLabelsThrowsError(self):
-    """
-    A KeyError should be thrown when there are not corresponding windows labels
-    for a data file (or vice-versa) in the corpus.
-    """
+  def testNonexistentDatafileForLabelsThrowsError(self):
     data = pandas.DataFrame({"timestamp" :
       generateTimestamps(strp("2014-01-01"),
       datetime.timedelta(minutes=5), 10)})
 
     windows = [["2014-01-01 00:15", "2014-01-01 00:30"]]
 
-    # Case 1: nonexistent datafile for window labels
     writeCorpus(self.tempCorpusPath, {"test_data_file.csv": data})
     writeCorpusLabel(self.tempCorpusLabelPath,
       {"test_data_file.csv": windows, "non_existent_data_file.csv": windows})
-    
-    corpus = nab.corpus.Corpus(self.tempCorpusPath)
-
-    self.assertRaises(
-      KeyError, nab.labeler.CorpusLabel, self.tempCorpusLabelPath, corpus)
-  
-    # Case 2: nonexistent window labels for datafile
-    writeCorpus(self.tempCorpusPath,
-      {"test_data_file.csv": data, "non_existent_data_file.csv": data})
-    writeCorpusLabel(self.tempCorpusLabelPath, {"test_data_file.csv": windows})
     
     corpus = nab.corpus.Corpus(self.tempCorpusPath)
 

--- a/tests/integration/corpuslabel_test.py
+++ b/tests/integration/corpuslabel_test.py
@@ -115,19 +115,34 @@ class CorpusLabelTest(unittest.TestCase):
             % (row[1]["timestamp"], relativePath))
 
 
-  def testNonexistentDataFileForLabels(self):
+  def testNonexistentDatafileOrLabelsThrowsError(self):
+    """
+    A KeyError should be thrown when there are not corresponding windows labels
+    for a data file (or vice-versa) in the corpus.
+    """
     data = pandas.DataFrame({"timestamp" :
       generateTimestamps(strp("2014-01-01"),
       datetime.timedelta(minutes=5), 10)})
 
     windows = [["2014-01-01 00:15", "2014-01-01 00:30"]]
 
+    # Case 1: nonexistent datafile for window labels
     writeCorpus(self.tempCorpusPath, {"test_data_file.csv": data})
     writeCorpusLabel(self.tempCorpusLabelPath,
       {"test_data_file.csv": windows, "non_existent_data_file.csv": windows})
     
     corpus = nab.corpus.Corpus(self.tempCorpusPath)
+
+    self.assertRaises(
+      KeyError, nab.labeler.CorpusLabel, self.tempCorpusLabelPath, corpus)
+  
+    # Case 2: nonexistent window labels for datafile
+    writeCorpus(self.tempCorpusPath,
+      {"test_data_file.csv": data, "non_existent_data_file.csv": data})
+    writeCorpusLabel(self.tempCorpusLabelPath, {"test_data_file.csv": windows})
     
+    corpus = nab.corpus.Corpus(self.tempCorpusPath)
+
     self.assertRaises(
       KeyError, nab.labeler.CorpusLabel, self.tempCorpusLabelPath, corpus)
 

--- a/tests/integration/corpuslabel_test.py
+++ b/tests/integration/corpuslabel_test.py
@@ -115,34 +115,19 @@ class CorpusLabelTest(unittest.TestCase):
             % (row[1]["timestamp"], relativePath))
 
 
-  def testNonexistentDatafileOrLabelsThrowsError(self):
-    """
-    A KeyError should be thrown when there are not corresponding windows labels
-    for a data file (or vice-versa) in the corpus.
-    """
+  def testNonexistentDataFileForLabels(self):
     data = pandas.DataFrame({"timestamp" :
       generateTimestamps(strp("2014-01-01"),
       datetime.timedelta(minutes=5), 10)})
 
     windows = [["2014-01-01 00:15", "2014-01-01 00:30"]]
 
-    # Case 1: nonexistent datafile for window labels
     writeCorpus(self.tempCorpusPath, {"test_data_file.csv": data})
     writeCorpusLabel(self.tempCorpusLabelPath,
       {"test_data_file.csv": windows, "non_existent_data_file.csv": windows})
     
     corpus = nab.corpus.Corpus(self.tempCorpusPath)
-
-    self.assertRaises(
-      KeyError, nab.labeler.CorpusLabel, self.tempCorpusLabelPath, corpus)
-  
-    # Case 2: nonexistent window labels for datafile
-    writeCorpus(self.tempCorpusPath,
-      {"test_data_file.csv": data, "non_existent_data_file.csv": data})
-    writeCorpusLabel(self.tempCorpusLabelPath, {"test_data_file.csv": windows})
     
-    corpus = nab.corpus.Corpus(self.tempCorpusPath)
-
     self.assertRaises(
       KeyError, nab.labeler.CorpusLabel, self.tempCorpusLabelPath, corpus)
 


### PR DESCRIPTION
@subutai the changes in #180 remove some of the functionality that was tested by `testNonexistentDatafileOrLabelsThrowsError()`