### PR TITLE
be more efficient about constructing detector results DF

### DIFF
--- a/nab/detectors/base.py
+++ b/nab/detectors/base.py
@@ -100,7 +100,7 @@ class AnomalyDetector(object):
 
     headers = self.getHeader()
 
-    ans = pandas.DataFrame(columns=headers)
+    rows = []
     for i, row in self.dataSet.data.iterrows():
 
       inputData = row.to_dict()
@@ -109,13 +109,14 @@ class AnomalyDetector(object):
 
       outputRow = list(row) + list(detectorValues)
 
-      ans.loc[i] = outputRow
+      rows.append(outputRow)
 
       # Progress report
       if (i % 1000) == 0:
         print ".",
         sys.stdout.flush()
 
+    ans = pandas.DataFrame(rows, columns=headers)
     return ans
 
 


### PR DESCRIPTION
Appending rows to DataFrames is expensive. 
This change speeds up the detection phase by around 10X in my testing.

(Even better would have been to pre-allocate np arrays for the DataFrame
constructor, but needed type information isn't available without some plumbing)
