### PR TITLE
Handling alternative directory separators

### DIFF
--- a/nab/corpus.py
+++ b/nab/corpus.py
@@ -135,7 +135,7 @@ class Corpus(object):
     dataSets = [DataFile(path) for path in filePaths if ".csv" in path]
 
     def getRelativePath(srcRoot, srcPath):
-      return srcPath[srcPath.index(srcRoot)+len(srcRoot):].strip("/")
+      return srcPath[srcPath.index(srcRoot)+len(srcRoot):].strip(os.path.sep).replace(os.path.sep, "/")
 
     return {getRelativePath(self.srcRoot, d.srcPath) : d for d in dataSets}
 
@@ -180,8 +180,8 @@ class Corpus(object):
     @param newRoot      (string)      Location of new directory to copy corpus
                                       to.
     """
-    if newRoot[-1] != "/":
-      newRoot += "/"
+    if newRoot[-1] != os.path.sep:
+      newRoot += os.path.sep
     if os.path.isdir(newRoot):
       print "directory already exists"
       return None

--- a/nab/corpus.py
+++ b/nab/corpus.py
@@ -135,7 +135,8 @@ class Corpus(object):
     dataSets = [DataFile(path) for path in filePaths if ".csv" in path]
 
     def getRelativePath(srcRoot, srcPath):
-      return srcPath[srcPath.index(srcRoot)+len(srcRoot):].strip(os.path.sep).replace(os.path.sep, "/")
+      return srcPath[srcPath.index(srcRoot)+len(srcRoot):]\
+        .strip(os.path.sep).replace(os.path.sep, "/")
 
     return {getRelativePath(self.srcRoot, d.srcPath) : d for d in dataSets}
 

--- a/nab/runner.py
+++ b/nab/runner.py
@@ -270,7 +270,7 @@ class Runner(object):
         score = 100 * (results["Score"].iloc[-1] - base) / (perfect - base)
 
         # Add to results dict:
-        resultsInfo = resultsFile.split('/')[-1].split('.')[0]
+        resultsInfo = resultsFile.split(os.path.sep)[-1].split('.')[0]
         detector = resultsInfo.split('_')[0]
         profile = resultsInfo.replace(detector + "_", "").replace("_scores", "")
         if detector not in finalResults:

--- a/nab/util.py
+++ b/nab/util.py
@@ -173,7 +173,7 @@ def absoluteFilePaths(directory):
   for dirpath,_,filenames in os.walk(directory):
     filenames = [f for f in filenames if not f[0] == "."]
     for f in filenames:
-      yield os.path.abspath(os.path.join(dirpath, f))
+      yield os.path.abspath(os.path.normpath(os.path.join(dirpath, f)))
 
 
 def makeDirsExist(dirname):
@@ -250,7 +250,7 @@ def convertResultsPathToDataPath(path):
 
   @return     (string)  Path to dataset result in the result directory.
   """
-  path = path.split("/")
+  path = path.split(os.path.sep)
   detector = path[0]
   path = path[1:]
 

--- a/nab/util.py
+++ b/nab/util.py
@@ -173,7 +173,7 @@ def absoluteFilePaths(directory):
   for dirpath,_,filenames in os.walk(directory):
     filenames = [f for f in filenames if not f[0] == "."]
     for f in filenames:
-      yield os.path.abspath(os.path.normpath(os.path.join(dirpath, f)))
+      yield os.path.abspath(os.path.join(dirpath, f))
 
 
 def makeDirsExist(dirname):

--- a/run.py
+++ b/run.py
@@ -137,12 +137,12 @@ if __name__ == "__main__":
                          "null,numenta")
                     
   parser.add_argument("-p", "--profilesFile",
-                    default="config/profiles.json",
+                    default=os.path.join("config", "profiles.json"),
                     help="The configuration file to use while running the "
                     "benchmark.")
 
   parser.add_argument("-t", "--thresholdsFile",
-                    default="config/thresholds.json",
+                    default=os.path.join("config", "thresholds.json"),
                     help="The configuration file that stores thresholds for "
                     "each combination of detector and username")
 

--- a/tests/integration/corpuslabel_test.py
+++ b/tests/integration/corpuslabel_test.py
@@ -199,9 +199,9 @@ class CorpusLabelTest(unittest.TestCase):
 
     for i, labels in enumerate(rawLabels):
       labelsPath = self.tempCorpusLabelPath.replace(
-        "/label.json", "/raw/label{}.json".format(i))
+        os.path.sep+"label.json", os.path.sep+"raw"+os.path.sep+"label{}.json".format(i))
       writeCorpusLabel(labelsPath, {"test_data_file.csv": labels})
-    labelsDir = labelsPath.replace("/label{}.json".format(i), "")
+    labelsDir = labelsPath.replace(os.path.sep+"label{}.json".format(i), "")
 
     corpus = nab.corpus.Corpus(self.tempCorpusPath)
     labelCombiner = nab.labeler.LabelCombiner(


### PR DESCRIPTION
Changes to allow for handling of alternative directory separators, such as `\\` used on win32 os.platform machines.