### PR TITLE
RES-561: Fix pandas deprecation warnings.

### DIFF
--- a/nab/detectors/relative_entropy/relative_entropy_detector.py
+++ b/nab/detectors/relative_entropy/relative_entropy_detector.py
@@ -57,7 +57,7 @@ class RelativeEntropyDetector(AnomalyDetector):
     self.util = []
 
     # Number of bins into which util is to be quantized
-    self.N_bins = 5.0
+    self.N_bins = 5
 
     # Window size
     self.W = 52


### PR DESCRIPTION
Fixed the following warnings: 
- FutureWarning: pd.ewm_mean is deprecated for Series and will be removed in a future version, replace with Series.ewm(ignore_na=False,min_periods=0,adjust=True,com=50).mean()
 - FutureWarning: pd.ewm_std is deprecated for Series and will be removed in a future version, replace with Series.ewm(ignore_na=False,min_periods=0,adjust=True,com=50).std(bias=False)
 - FutureWarning: iget(i) is deprecated. Please use .iloc[i] or .iat[i]

@rhyolight @subutai Please review
