### PR TITLE
Noted Python 2 docker image availability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ NAB is a Python 3 framework, and can only integrate Python 3 detectors. The foll
     twitterADVec (R)
     random_cut_forest (AWS Kinesis Analytics)
 
-Instructions on how to run the each detector in their native environment can be found in the `nab/detectors/${name}` directory.
+Instructions on how to run the each detector in their native environment can be found in the `nab/detectors/${name}` directory. The Python 2 HTM detectors are also provided within a docker image, available with `docker pull numenta/nab:py2.7`.
 
 ##### Run full NAB
 

--- a/nab/detectors/htmjava/README.md
+++ b/nab/detectors/htmjava/README.md
@@ -13,6 +13,10 @@ the main repository for the following detectors:
 
 ## Installation
 
+### Docker
+
+This detector is also provided within a docker image, available with `docker pull numenta/nab:py2.7`.
+
 ### Java
 
 First make sure you have __java 8__ installed. You should see a version number matchin 1.8.XXXX.

--- a/nab/detectors/numenta/README.md
+++ b/nab/detectors/numenta/README.md
@@ -13,6 +13,12 @@ the main repository for the following detectors:
 
 ## Installation
 
+### Docker
+
+Both these detectors are also provided within a docker image, available with `docker pull numenta/nab:py2.7`.
+
+### Assumptions
+
 We assume you have a working version of Python 3 installed as your default Python.
 If your default system Python is still Python 2 you can skip the virtual environment
 creation below.


### PR DESCRIPTION
@lscheinkman Looks like we already had a [docker image](https://hub.docker.com/layers/numenta/nab/py2.7/images/sha256-cc4e8036867da1c11c4e9d3bfbea4798041f4b116c061119a4214674567de3c5), so I just updated the READMEs. I remember creating the dockerfile, but I don't remember tagging it. 🤷‍♂ 