### PR TITLE
add build support for python >3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,11 @@
-Cython==0.29.14
-pandas==0.23.3
+Cython==0.29.14; python_version <= '3.6'
+Cython==0.29.32; python_version > '3.6'
+pandas==0.23.3; python_version <= '3.6'
+pandas==1.5.1; python_version > '3.6'
 simplejson==3.11.1
-boto3==1.9.134
-scikit-learn==0.21.1; python_version >= '3.5'
-scikit-learn==0.20.1; python_version < '3.5'
-plotly==2.0.0
+boto3==1.9.134; python_version <= '3.6'
+boto3==1.24.95; python_version > '3.6'
+scikit-learn==0.21.1; python_version <= '3.6'
+scikit-learn==1.1.2; python_version > '3.6'
+plotly==2.0.0; python_version <= '3.6'
+plotly==5.10.0; python_version > '3.6'


### PR DESCRIPTION
python version is >=3.6 on most of OS distributions. add support to the python >3.6 to avoid build failure